### PR TITLE
Add CMakeLists.txt for easier builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ OLD/
 QCIR/
 Taste/
 Coco/
+
+# Build Directory
+build/
+build-*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.12)
+project(qcir-checker)
+
+# Define the sources.
+set(SRCS
+  ${CMAKE_CURRENT_SOURCE_DIR}/Scanner.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/Parser.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ParserLight.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/qcir.cpp
+)
+
+# Actually define the executable.
+add_executable(qcir.exe ${SRCS})
+
+# Enable Link-Time-Optimization (LTO) if supported.
+include(CheckIPOSupported)
+check_ipo_supported(RESULT lto_supported OUTPUT error)
+if(lto_supported)
+  message(STATUS "IPO / LTO supported")
+  if(NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+    message(STATUS "IPO / LTO enabled")
+    set_property(TARGET qcir.exe PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+  endif()
+else()
+  message(STATUS "IPO / LTO not supported: <${error}>")
+endif()
+
+# Add more warnings to the compiler output.
+target_compile_options(qcir.exe PRIVATE
+  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic>
+)

--- a/README.md
+++ b/README.md
@@ -4,8 +4,24 @@ Please use the .pdf to check the grammar, small example is provided in `small.qc
 To compile a project, use:`
 
 ```bash
-g++ Scanner.cpp Parser.cpp ParserLight.cpp qcir.cpp -o qcir.exe
+mkdir build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release
+make -j4
 ```
+
+During development, use:
+
+```bash
+mkdir build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+make -j4
+cd ..
+ln build/compile_commands.json
+```
+
+Your editor can then use the compile_commands.json for code completion.
 
 To run the programm, use:
 


### PR DESCRIPTION
Really nice project! Just checked it out.

This patch adds a `CMakeLists.txt` which makes cross-platform builds easier using [CMake](https://cmake.org/). It also makes it easier to have a Release and a Debug build, so optimizations can be tested out more easily. Hope this also works well for you and you like it!